### PR TITLE
Fix(parsing): Update selectors for Characters and Relates layout due to Bangumi DOM changes

### DIFF
--- a/app/src/main/java/com/xiaoyv/bangumi/ui/media/detail/character/MediaCharacterAdapter.kt
+++ b/app/src/main/java/com/xiaoyv/bangumi/ui/media/detail/character/MediaCharacterAdapter.kt
@@ -24,9 +24,18 @@ class MediaCharacterAdapter : BaseQuickDiffBindingAdapter<MediaCharacterEntity,
         binding.tvComment.text = String.format("讨论：%s", item.commentCount)
         binding.tvComment.isVisible = item.commentCount.isNotBlank()
         binding.tvJob.text = buildString {
-            append(item.personJob)
-            append(";")
-            append(item.personSex)
+            if (!item.personJob.isNullOrBlank()) {
+                append(item.personJob)
+            }
+            if (!item.personSex.isNullOrBlank()) {
+                if (isNotEmpty()) append(" ; ")
+                append(item.personSex)
+            }
+            if (!item.actors.isNullOrEmpty()) {
+                if (isNotEmpty()) append("\n")
+                append("CV: ")
+                append(item.actors?.joinToString(" / ") { it.name.toString() })
+            }
         }
     }
 

--- a/app/src/main/java/com/xiaoyv/bangumi/ui/media/detail/overview/binder/OverviewCharacterBinder.kt
+++ b/app/src/main/java/com/xiaoyv/bangumi/ui/media/detail/overview/binder/OverviewCharacterBinder.kt
@@ -56,7 +56,7 @@ class OverviewCharacterBinder(private val clickItemListener: (MediaDetailEntity.
             FragmentOverviewCharacterItemBinding>(IdDiffItemCallback()) {
         override fun BaseQuickBindingHolder<FragmentOverviewCharacterItemBinding>.converted(item: MediaDetailEntity.MediaCharacter) {
             binding.ivAvatar.loadImageAnimate(item.avatar, cropType = ImageView.ScaleType.FIT_START)
-            binding.tvName.text = item.characterNameCn.ifBlank { item.characterName }
+            binding.tvName.text = item.characterName.ifBlank { item.characterNameCn }
             binding.tvJobs.text = item.jobs.joinToString(";")
             binding.tvCommentCount.text = String.format("+%d", item.saveCount)
             binding.tvCommentCount.isVisible = item.saveCount != 0

--- a/lib-common/src/main/java/com/xiaoyv/common/api/parser/impl/MediaDetailParser.kt
+++ b/lib-common/src/main/java/com/xiaoyv/common/api/parser/impl/MediaDetailParser.kt
@@ -172,21 +172,31 @@ fun Document.parserMediaMakers(): List<MediaMakerEntity> {
 fun Document.parserMediaCharacters(): List<MediaCharacterEntity> {
     requireNoError()
 
-    return select("#columnInSubjectA > div").map {
+    return select("#columnInSubjectA .item").map {
         val entity = MediaCharacterEntity()
-        entity.id = it.select("h2 a").hrefId()
+        entity.id = it.select("a.avatar").hrefId()
         entity.avatar = it.select(".avatar img").attr("src").optImageUrl()
-        entity.titleCn = it.select("h2 .tip").text()
-        entity.titleNative = it.select("h2 a").firsTextNode()
-        entity.commentCount = it.select(".rr > .na").text()
-        entity.personJob = it.select(".prsn_info > .badge_job").text()
-        entity.personSex = it.select(".prsn_info > .tip").text()
+        entity.titleCn = it.select("h2 span.tip").text()
+        entity.titleNative = it.select("h2 a.l").text()
+        entity.commentCount = it.select(".rr > .primary").text()
+        
+        entity.personJob = it.select(".badge_job_tip").text()
+        // prsn_info contains the job text inside it. We substring it out to avoid duplication.
+        val rawSex = it.select(".prsn_info").text()
+        val jobStr = entity.personJob.orEmpty()
+        entity.personSex = if (jobStr.isNotEmpty() && rawSex.startsWith(jobStr)) {
+            rawSex.substringAfter(jobStr).trim()
+        } else {
+            rawSex
+        }
+
         entity.actors = it.select(".actorBadge").map { actor ->
             val actorBadge = MediaCharacterEntity.ActorBadge()
             actorBadge.id = actor.select("a.avatar").hrefId()
+            // Fix: the image is usually located directly inside the a tag
             actorBadge.avatar = actor.select("a.avatar img").attr("src").optImageUrl()
             actorBadge.name = actor.select("p a.l").text()
-            actorBadge.nameCn = actor.select("p small").text()
+            actorBadge.nameCn = actor.select("p small.grey").text()
             actorBadge
         }
         entity
@@ -362,19 +372,19 @@ fun Document.parserMediaDetail(): MediaDetailEntity {
     }.filterNotNull()
 
     // 角色
-    entity.characters = subjectDetail.select("#browserItemList > li").map { item ->
+    entity.characters = select("#browserItemList > li").map { item ->
         val mediaCharacter = MediaDetailEntity.MediaCharacter()
-        mediaCharacter.saveCount = item.select(".userContainer .fade").text().parseCount()
-        item.select(".userContainer a.avatar").apply {
+        mediaCharacter.saveCount = item.select(".info .primary").text().parseCount()
+        item.select("a.thumbTip").apply {
             mediaCharacter.id = hrefId()
             mediaCharacter.characterName = attr("title")
-            mediaCharacter.avatar = select(".userImage > span").attr("style")
+            mediaCharacter.avatar = select(".avatarNeue").attr("style")
                 .fetchStyleBackgroundUrl().optImageUrl()
         }
-        item.select(".info .tip_j").apply {
+        item.select(".info").apply {
             mediaCharacter.jobs = select(".badge_job_tip").map { it.text() }
-            mediaCharacter.characterNameCn = select("span.tip").text()
-            mediaCharacter.persons = select("a").map { person ->
+            mediaCharacter.characterNameCn = select(".title a").text()
+            mediaCharacter.persons = select(".badge_actor a").map { person ->
                 val characterPerson = MediaDetailEntity.MediaCharacterPerson()
                 characterPerson.personName = person.text()
                 characterPerson.personId = person.hrefId()
@@ -402,7 +412,7 @@ fun Document.parserMediaDetail(): MediaDetailEntity {
     }
 
     // 关联的条目
-    entity.relativeMedia = subjectDetail.select(".browserCoverMedium > li").map { item ->
+    entity.relativeMedia = select("ul.browserCoverMedium:not(#browserItemList) > li").map { item ->
         val mediaRelative = MediaDetailEntity.MediaRelative()
         mediaRelative.type = item.select("span.sub").text()
         item.select("a.avatar").apply {


### PR DESCRIPTION
- 问题描述 (Background & Issues)
近期 Bangumi 对其网页端的 HTML DOM 结构进行了升级，导致 App 中 MediaDetailParser 层的旧版解析器失效，从而在应用内衍生出以下几处明显的 Bug  (部分报告于Issue #100)：

1. 概览界面 - 角色区域空白：原本存放角色属性的 .userContainer 类被移除，导致旧的选取器无法拉取到任何角色数据。
2. 概览界面 - 关联条目数据错乱：网页抽离了原本作为解析容器的 #columnSubjectHomeB。当使用全局统配遍历 select(".browserCoverMedium > li") 时，会把同样由该 class 声明渲染的「角色们」误认为成「关联条目」一并抓取下来，导致列表混淆、名字占据以及封面图片失效。
3. 角色 Tab 界面 - 列表挤压成组：新版网页将所有的独立角色 div.item 全数被打包进了一个新增的 <div class="browserList"> 父容器中。因此导致在执行原生 select("#columnInSubjectA > div") 子代筛选时，程序错误地将所有角色的集合当做一个单一的条目对象进行了解析。

- 修复与改动细节 (Changes & Fixes)

1. 修正解析器层 (MediaDetailParser.kt)

针对关联条目 (Relates) 增加伪类剔除：修改选取器为 select("ul.browserCoverMedium:not(#browserItemList) > li")，完美避免其抓取到上方共享类的角色集列表。

重构了概览页面角色的字段抓取器：适配最新站点，改用 .info .primary 抓取讨论数、a.thumbTip 抓取原名与 ID 以及 .avatarNeue 替换原先消失的 .userContainer 相关节点。

重构了角色 Tab (parserMediaCharacters) 的数据分割：将提取准星精确锁定在了 #columnInSubjectA .item 实现了单个脱离解析；重编了 CV (actorBadge) 内容抓取逻辑。同时对 prsn_info 返回的冗长字符通过代码实现了字符串剔除，修复了“职务”（例如“主角”）和“职务性别”（例如“主角 性别 女”）复刻拼贴导致的文字叠加问题。

2. 修正布局适配与数据绑定层 (MediaCharacterAdapter.kt & OverviewCharacterBinder.kt)

补全逻辑：原本的角色详情（FragmentMediaCharacterItemBinding）被遗漏未显示 CV 相关内容（item.actors）。现在将其恢复，并会在“职称; 性别”字段底部另起一行展示相应的配音演员 (CV) 信息。

体验优化：在概览界面的角色头像下方，调换了名称回退逻辑，现在优先展示原著名称（characterName，与网页端行为保持一致），若空才展示中文译名（characterNameCn）。

- 测试与验证度 (Verification)
已成功编译运行并通过模拟器/实体机测试。
详情界面的「角色」、「关联条目」均能正常回显原图、触发点击以及显示热度标记。
拥有复杂配音成员组合和没有附带 CV 资料的角色，在角色二级列表中都会干净、独立成行地展现预期文本格式。