### PR TITLE
Fix: Missing Bearer token when using proxy. Add selectable text to BgmText

### DIFF
--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/api/client/BgmApiClient.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/api/client/BgmApiClient.kt
@@ -305,7 +305,7 @@ class BgmApiClient(
         install(Auth) {
             bearer {
                 sendWithoutRequest { builder ->
-                    builder.url.host.equals("api.bgm.tv", true)
+                    builder.url.toString().contains("api.bgm.tv", ignoreCase = true)
                 }
 
                 loadTokens {
@@ -331,6 +331,7 @@ class BgmApiClient(
 
                     if (token == ComposeAuthToken.Empty) {
                         preferenceStore.userInfo = ComposeUser.Empty
+                        preferenceStore.userToken = ComposeAuthToken.Empty
                         null
                     } else {
                         preferenceStore.userToken = token
@@ -368,4 +369,3 @@ class BgmApiClient(
         tokenEntity
     }
 }
-

--- a/shared/ui/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/ui/component/text/BmgText.kt
+++ b/shared/ui/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/ui/component/text/BmgText.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -208,26 +209,29 @@ fun BgmLinkedText(
 
         var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
 
-        BasicText(
-            text = content,
-            modifier = Modifier.pointerInput(content, actionHandler) {
-                awaitHtmlEvent(
-                    text = content,
-                    onTextLayoutResult = { layoutResult },
-                    onClickLink = { range -> actionHandler.openBgmLink(range.item) },
-                    onClickMask = { range ->
-                        val key = packTextRangeKey(range.start, range.end)
-                        if (!targetShowMasks.remove(key)) targetShowMasks.add(key)
-                    },
-                    onClickImage = { range -> actionHandler.openImage(range.item) },
-                )
-            },
-            style = resolvedTextStyle,
-            inlineContent = inlineContent,
-            overflow = TextOverflow.Clip,
-            maxLines = maxLines,
-            minLines = minLines,
-            onTextLayout = { layoutResult = it }
-        )
+        // 文字可选中
+        SelectionContainer {
+            BasicText(
+                text = content,
+                modifier = Modifier.pointerInput(content, actionHandler) {
+                    awaitHtmlEvent(
+                        text = content,
+                        onTextLayoutResult = { layoutResult },
+                        onClickLink = { range -> actionHandler.openBgmLink(range.item) },
+                        onClickMask = { range ->
+                            val key = packTextRangeKey(range.start, range.end)
+                            if (!targetShowMasks.remove(key)) targetShowMasks.add(key)
+                        },
+                        onClickImage = { range -> actionHandler.openImage(range.item) },
+                    )
+                },
+                style = resolvedTextStyle,
+                inlineContent = inlineContent,
+                overflow = TextOverflow.Clip,
+                maxLines = maxLines,
+                minLines = minLines,
+                onTextLayout = { layoutResult = it }
+            )
+        }
     }
 }


### PR DESCRIPTION
* 修复在使用proxy的时候，无法添加上Bearer token的问题，导致token/cookie失效时标记番剧401。
* 增加初步的文字可选，但不是所有文字都可选。