### PR TITLE
feat: 增加角色CV表、修复HTTP 401

### DIFF
--- a/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/business/MonoDetailState.kt
+++ b/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/business/MonoDetailState.kt
@@ -60,6 +60,7 @@ data class MonoDetailState(
         } else {
             persistentListOf(
                 ComposeTextTab(MonoDetailTab.OVERVIEW, Res.string.subject_tab_overview),
+                ComposeTextTab(MonoDetailTab.CASTS, Res.string.global_character),
                 ComposeTextTab(MonoDetailTab.COLLECTIONS, Res.string.global_collection),
                 ComposeTextTab(MonoDetailTab.ALBUM, Res.string.global_album),
                 ComposeTextTab(MonoDetailTab.PIXIV, Res.string.global_pixiv),

--- a/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/page/MonoDetailCastsScreen.kt
+++ b/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/page/MonoDetailCastsScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,17 +68,32 @@ fun MonoDetailCastsScreen(
     onActionEvent: (MonoDetailEvent.Action) -> Unit,
 ) {
     if (LocalInspectionMode.current) return
-    val viewModel = koinMonoDetailCastsViewModel(param = remember {
-        ListPersonCastParam(
-            personId = state.id,
-        )
-    })
 
-    StateLazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        pagingItems = viewModel.casts.collectAsLazyPagingItems()
-    ) { item, index ->
-        MonoCastItem(item, state, onUiEvent)
+    if (state.type == MonoType.CHARACTER) {
+        // 角色类型：数据已在 MonoDetailViewModel 中加载到 state.casts
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(
+                items = state.casts,
+                key = { it.subject.id },
+                contentType = { "CharacterCast" }
+            ) { item ->
+                MonoCastItem(item, state, onUiEvent)
+            }
+        }
+    } else {
+        // 人物类型：使用分页加载
+        val viewModel = koinMonoDetailCastsViewModel(param = remember {
+            ListPersonCastParam(
+                personId = state.id,
+            )
+        })
+
+        StateLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            pagingItems = viewModel.casts.collectAsLazyPagingItems()
+        ) { item, index ->
+            MonoCastItem(item, state, onUiEvent)
+        }
     }
 }
 
@@ -142,12 +159,12 @@ private fun MonoCharacterCastItem(
             }
         }
 
-        if (item.actors.isNotEmpty()) Column(
+        if (item.characterCasts.isNotEmpty()) Column(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(LayoutPadding)
         ) {
             // 角色出演对应的CV
-            item.actors.forEach {
+            item.characterCasts.forEach { cast ->
                 Row(horizontalArrangement = Arrangement.spacedBy(LayoutPadding)) {
                     Column(
                         modifier = Modifier.weight(1f),
@@ -156,7 +173,7 @@ private fun MonoCharacterCastItem(
                     ) {
                         Text(
                             modifier = Modifier,
-                            text = it.displayName,
+                            text = cast.person.displayName,
                             textAlign = TextAlign.End,
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis,
@@ -170,9 +187,9 @@ private fun MonoCharacterCastItem(
                     }
                     InfoImage(
                         modifier = Modifier.width(60.dp),
-                        model = it.images.displayMediumImage,
+                        model = cast.person.images.displayMediumImage,
                         onClick = {
-                            onUiEvent(MonoDetailEvent.UI.OnNavScreen(Screen.MonoDetail(it.id, MonoType.PERSON)))
+                            onUiEvent(MonoDetailEvent.UI.OnNavScreen(Screen.MonoDetail(cast.person.id, MonoType.PERSON)))
                         }
                     )
                 }

--- a/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/page/MonoDetailCollabsScreen.kt
+++ b/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/page/MonoDetailCollabsScreen.kt
@@ -1,11 +1,37 @@
 package com.xiaoyv.bangumi.features.mono.detail.page
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.xiaoyv.bangumi.features.mono.detail.business.MonoDetailEvent
 import com.xiaoyv.bangumi.features.mono.detail.business.MonoDetailState
+import com.xiaoyv.bangumi.shared.core.types.MonoType
+import com.xiaoyv.bangumi.shared.core.utils.clickWithoutRipped
+import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMonoCollab
+import com.xiaoyv.bangumi.shared.ui.component.image.InfoImage
+import com.xiaoyv.bangumi.shared.ui.component.navigation.Screen
+import com.xiaoyv.bangumi.shared.ui.component.space.LayoutPadding
+import com.xiaoyv.bangumi.shared.ui.component.space.LayoutPaddingHalf
 
 /**
  * [MonoDetailCollabsScreen]
+ *
+ * 人物/角色的合作者页面，从 webInfo.collabs 获取数据
  *
  * @since 2025/5/18
  */
@@ -15,5 +41,87 @@ fun MonoDetailCollabsScreen(
     onUiEvent: (MonoDetailEvent.UI) -> Unit,
     onActionEvent: (MonoDetailEvent.Action) -> Unit,
 ) {
+    val collabs = state.mono.webInfo.collabs
 
+    if (collabs.isEmpty()) {
+        // 无合作数据时显示空状态
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(LayoutPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "暂无合作信息",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+
+    LazyVerticalGrid(
+        modifier = Modifier.fillMaxSize(),
+        columns = GridCells.Adaptive(minSize = 100.dp),
+        contentPadding = PaddingValues(LayoutPadding),
+        horizontalArrangement = Arrangement.spacedBy(LayoutPadding),
+        verticalArrangement = Arrangement.spacedBy(LayoutPadding),
+    ) {
+        items(
+            items = collabs,
+            key = { it.id },
+            contentType = { "Collab" }
+        ) { collab ->
+            CollabItem(
+                collab = collab,
+                onClick = {
+                    onUiEvent(
+                        MonoDetailEvent.UI.OnNavScreen(
+                            Screen.MonoDetail(collab.id, MonoType.PERSON)
+                        )
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CollabItem(
+    collab: ComposeMonoCollab,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .clickWithoutRipped(onClick = onClick)
+            .width(100.dp)
+            .padding(vertical = LayoutPaddingHalf),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(LayoutPaddingHalf),
+    ) {
+        InfoImage(
+            modifier = Modifier
+                .width(70.dp),
+            model = collab.images.displayMediumImage,
+            onClick = onClick,
+        )
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = collab.name,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        if (collab.count.isNotBlank()) {
+            Text(
+                text = "${collab.count}次合作",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }

--- a/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/page/MonoDetailMainScreen.kt
+++ b/features/mono/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/mono/detail/page/MonoDetailMainScreen.kt
@@ -14,11 +14,14 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.xiaoyv.bangumi.core_resource.resources.Res
+import com.xiaoyv.bangumi.core_resource.resources.global_collabs
 import com.xiaoyv.bangumi.core_resource.resources.global_detail
 import com.xiaoyv.bangumi.core_resource.resources.global_no_summary
 import com.xiaoyv.bangumi.core_resource.resources.global_related_index
@@ -32,7 +35,9 @@ import com.xiaoyv.bangumi.features.mono.detail.business.MonoDetailState
 import com.xiaoyv.bangumi.shared.core.types.MonoDetailTab
 import com.xiaoyv.bangumi.shared.core.types.MonoType
 import com.xiaoyv.bangumi.shared.core.utils.clickWithoutRipped
+import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMonoCollab
 import com.xiaoyv.bangumi.shared.ui.component.divider.BgmHorizontalDivider
+import com.xiaoyv.bangumi.shared.ui.component.image.InfoImage
 import com.xiaoyv.bangumi.shared.ui.component.layout.state.itemKey
 import com.xiaoyv.bangumi.shared.ui.component.navigation.Screen
 import com.xiaoyv.bangumi.shared.ui.component.space.LayoutPadding
@@ -48,6 +53,8 @@ private const val ItemSummary = "KeySummary"
 private const val ItemInfo = "KeyInfo"
 private const val ItemPersonCharacter = "KeyPersonCharacter"
 private const val ItemCharacterSubject = "KeyCharacterSubject"
+private const val ItemCollab = "KeyCollab"
+private const val ItemTitleCollab = "KeyTitleCollab"
 private const val ItemIndex = "ItemIndex"
 private const val ItemTitleComment = "TitleComment"
 private const val ItemTitleCharacterSubject = "KeyTitleCharacterSubject"
@@ -122,6 +129,48 @@ fun MonoDetailMainScreen(
                         onUiEvent(MonoDetailEvent.UI.OnNavScreen(Screen.SubjectDetail(it.subject.id)))
                     }
                 )
+            }
+        }
+
+        // 合作者
+        if (state.mono.webInfo.collabs.isNotEmpty()) {
+            itemKey(ItemTitleCollab) {
+                DetailSectionTitle(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = LayoutPadding, bottom = LayoutPaddingHalf),
+                    title = stringResource(Res.string.global_collabs),
+                    action = stringResource(Res.string.subject_action_more),
+                    onActionClick = {
+                        onUiEvent(MonoDetailEvent.UI.OnSelectedPageType(MonoDetailTab.COLLABS))
+                    }
+                )
+            }
+            itemKey(ItemCollab) {
+                LazyRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .animateContentSize(),
+                    contentPadding = PaddingValues(horizontal = LayoutPadding),
+                    horizontalArrangement = Arrangement.spacedBy(LayoutPadding)
+                ) {
+                    items(
+                        state.mono.webInfo.collabs,
+                        key = { it.id },
+                        contentType = { "Collab" }
+                    ) { collab ->
+                        MonoDetailCollabPreviewItem(
+                            collab = collab,
+                            onClick = {
+                                onUiEvent(
+                                    MonoDetailEvent.UI.OnNavScreen(
+                                        Screen.MonoDetail(collab.id, MonoType.PERSON)
+                                    )
+                                )
+                            }
+                        )
+                    }
+                }
             }
         }
 
@@ -246,6 +295,43 @@ private fun MonoDetailIndexList(
                     }
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun MonoDetailCollabPreviewItem(
+    collab: ComposeMonoCollab,
+    onClick: () -> Unit,
+) {
+    androidx.compose.foundation.layout.Column(
+        modifier = Modifier
+            .clickWithoutRipped(onClick = onClick)
+            .width(80.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(LayoutPaddingHalf),
+    ) {
+        InfoImage(
+            modifier = Modifier.width(60.dp),
+            model = collab.images.displayMediumImage,
+            onClick = onClick,
+        )
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = collab.name,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodySmall,
+        )
+
+        if (collab.count.isNotBlank()) {
+            Text(
+                text = collab.count,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/api/client/BgmApiClient.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/api/client/BgmApiClient.kt
@@ -310,7 +310,7 @@ class BgmApiClient(
 
                 loadTokens {
                     val token = preferenceStore.userToken
-                    if (token.accessToken.isBlank() || token.refreshToken.isBlank()) null else {
+                    if (token.accessToken.isBlank() || token.refreshToken.isBlank() || token.isExpire) null else {
                         BearerTokens(accessToken = token.accessToken, refreshToken = token.refreshToken)
                     }
                 }

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoCast.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoCast.kt
@@ -1,0 +1,25 @@
+package com.xiaoyv.bangumi.shared.data.model.response.bgm
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * [ComposeMonoCast]
+ *
+ * 角色出演条目中的CV（声优）信息
+ * 对应 next.bgm.tv API 中 character casts 的嵌套结构
+ *
+ * @since 2025/7/27
+ */
+@Immutable
+@Serializable
+data class ComposeMonoCast(
+    @SerialName("person") val person: ComposeMono = ComposeMono.Empty,
+    @SerialName("relation") val relation: String = "",
+    @SerialName("summary") val summary: String = "",
+) {
+    companion object {
+        val Empty = ComposeMonoCast()
+    }
+}

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoCollab.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoCollab.kt
@@ -1,0 +1,25 @@
+package com.xiaoyv.bangumi.shared.data.model.response.bgm
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * [ComposeMonoCollab]
+ *
+ * 人物/角色的合作者信息，从网页 HTML 的 ul.coversSmall 解析
+ *
+ * @since 2025/7/27
+ */
+@Immutable
+@Serializable
+data class ComposeMonoCollab(
+    @SerialName("id") val id: Long = 0,
+    @SerialName("name") val name: String = "",
+    @SerialName("images") val images: ComposeImages = ComposeImages.Empty,
+    @SerialName("count") val count: String = "",
+) {
+    companion object {
+        val Empty = ComposeMonoCollab()
+    }
+}

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoInfo.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoInfo.kt
@@ -33,6 +33,12 @@ data class ComposeMonoInfo(
     @SerialName("actors") val actors: SerializeList<ComposeMono> = persistentListOf(),
 
     /**
+     * 角色详情页内查询出演条目才会填充
+     * 对应 API 中 casts 数组，每项包含 person(声优)、relation、summary
+     */
+    @SerialName("casts") val characterCasts: SerializeList<ComposeMonoCast> = persistentListOf(),
+
+    /**
      * 条目详情页内查询相关人物才会填充
      */
     @SerialName("order") val order: Int = 0,

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoWebInfo.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/bgm/ComposeMonoWebInfo.kt
@@ -19,6 +19,7 @@ data class ComposeMonoWebInfo(
     @SerialName("shortInfo") val shortInfo: String = "",
     @SerialName("indexList") val indexList: SerializeList<ComposeIndex> = persistentListOf(),
     @SerialName("comments") val comments: SerializeList<ComposeComment> = persistentListOf(),
+    @SerialName("collabs") val collabs: SerializeList<ComposeMonoCollab> = persistentListOf(),
 ) {
     companion object Companion {
         val Empty: ComposeMonoWebInfo = ComposeMonoWebInfo()

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/parser/bgm/MonoParser.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/parser/bgm/MonoParser.kt
@@ -18,6 +18,7 @@ import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeImages
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.index.ComposeIndex
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeInfobox
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMono
+import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMonoCollab
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMonoDisplay
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMonoInfo
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeMonoWebInfo
@@ -63,11 +64,25 @@ class MonoParser(private val commentParser: CommentParser) : BaseParser() {
             )
         }
 
+        // 解析合作者列表 (ul.coversSmall)
+        val collabs = select("ul.coversSmall > li").map { li ->
+            val href = li.select("a.avatar").attr("href")
+            val coverUrl = li.select("span.coverNeue").styleAvatarUrl()
+                .replace("/crt/m/", "/crt/g/")
+            ComposeMonoCollab(
+                id = href.substringAfterLast("/").toLongOrNull() ?: 0,
+                name = li.select("a.l").text(),
+                images = ComposeImages.fromUrl(coverUrl),
+                count = li.select("small").text().replace("(", "").replace(")", ""),
+            )
+        }
+
         return ComposeMonoWebInfo(
             info = info,
             indexList = indexList.toPersistentList(),
             shortInfo = shortInfo,
             comments = comments.toPersistentList(),
+            collabs = collabs.toPersistentList(),
         )
     }
 


### PR DESCRIPTION
- loadTokens 从未检查 token.isExpire，导致过期 token 被发送后服务器直接返回 401。修复后 Ktor Auth 会在 token 过期前主动刷新。
- 不显示CV：API 返回的字段名是 casts，但模型用的是 actors，反序列化时 CV 数据被丢弃。修复：新建了 ComposeMonoCast 模型并添加 characterCasts 字段，UI 也做了相应适配。同时为角色页面增加了 CASTS tab。
- 声优合作页：MonoDetailCollabsScreen 完全是空实现，且整个数据链路都缺失。修复：参照 election 版本的 HTML 解析方式（ul.coversSmall li），完整实现了数据模型、解析器、UI 页面和概览预览区。

编译验证通过。