### PR TITLE
美化搜索框，无限历史记录显示，优化bangumi和豆瓣词条匹配算法

### DIFF
--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputNavigator.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputNavigator.kt
@@ -1,6 +1,7 @@
 package com.xiaoyv.bangumi.features.search.input
 
 import com.xiaoyv.bangumi.shared.ui.component.navigation.Screen
+import com.xiaoyv.bangumi.shared.ui.component.navigation.StackAction
 import com.xiaoyv.bangumi.shared.ui.component.navigation.navScope
 import com.xiaoyv.bangumi.shared.ui.component.navigation.navigator
 import org.koin.compose.viewmodel.koinViewModel
@@ -13,7 +14,12 @@ val searchInputModule = module {
         navigation<Screen.SearchInput> { key ->
             SearchInputRoute(
                 viewModel = koinViewModel { parametersOf(key) },
-                onNavScreen = { navigator.navigate(it) },
+                onNavScreen = {
+                    navigator.navigate(
+                        it,
+                        stackAction = StackAction.PopUpTo(key, inclusive = true)
+                    )
+                },
                 onNavUp = { navigator.goBack() }
             )
         }

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputNavigator.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputNavigator.kt
@@ -17,7 +17,7 @@ val searchInputModule = module {
                 onNavScreen = {
                     navigator.navigate(
                         it,
-                        stackAction = StackAction.PopUpTo(key, inclusive = true)
+                        stackAction = StackAction.PopUpTo(Screen.Main)
                     )
                 },
                 onNavUp = { navigator.goBack() }

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputScreen.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputScreen.kt
@@ -1,7 +1,9 @@
 package com.xiaoyv.bangumi.features.search.input
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,11 +11,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Search
@@ -45,13 +49,11 @@ import com.xiaoyv.bangumi.features.search.input.business.SearchInputState
 import com.xiaoyv.bangumi.features.search.input.business.SearchInputViewModel
 import com.xiaoyv.bangumi.shared.core.mvi.BaseState
 import com.xiaoyv.bangumi.shared.core.utils.asTextFieldValue
-import com.xiaoyv.bangumi.shared.ui.component.bar.BgmTopAppBar
 import com.xiaoyv.bangumi.shared.ui.component.layout.state.StateLayout
 import com.xiaoyv.bangumi.shared.ui.component.navigation.Screen
 import com.xiaoyv.bangumi.shared.ui.component.text.BmgTextField
 import com.xiaoyv.bangumi.shared.ui.kts.collectBaseSideEffect
 import com.xiaoyv.bangumi.shared.ui.theme.BgmIcons
-import com.xiaoyv.bangumi.shared.ui.theme.BgmIconsMirrored
 import com.xiaoyv.bangumi.shared.ui.theme.contentMargin
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -100,15 +102,46 @@ private fun SearchInputScreen(
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            BgmTopAppBar(
-                modifier = Modifier.fillMaxWidth(),
-                navigationIcon = null,
-                titleContent = {
-                    baseState.content {
-                        SearchInputBar(this, onUiEvent, onActionEvent)
-                    }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(TopAppBarDefaults.windowInsets)
+                    .height(TopAppBarDefaults.TopAppBarExpandedHeight)
+            ) {
+                baseState.content {
+                    SearchInputBar(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.Center),
+                        state = this,
+                        onActionEvent = onActionEvent,
+                    )
                 }
-            )
+
+                IconButton(
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .padding(start = 4.dp),
+                    onClick = { onUiEvent(SearchInputEvent.UI.OnNavUp) },
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = stringResource(Res.string.global_back),
+                    )
+                }
+
+                IconButton(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 4.dp),
+                    onClick = { onActionEvent(SearchInputEvent.Action.OnSearch) },
+                ) {
+                    Icon(
+                        imageVector = BgmIcons.Search,
+                        contentDescription = stringResource(Res.string.global_search),
+                    )
+                }
+            }
         }
     ) {
         StateLayout(
@@ -159,14 +192,13 @@ private fun SearchInputScreenContent(
 
 @Composable
 private fun SearchInputBar(
+    modifier: Modifier = Modifier,
     state: SearchInputState,
-    onUiEvent: (SearchInputEvent.UI) -> Unit,
     onActionEvent: (SearchInputEvent.Action) -> Unit,
 ) {
     BmgTextField(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = contentMargin - 12.dp, end = contentMargin),
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 56.dp, vertical = 14.dp),
         value = state.query,
         onValueChange = { onActionEvent(SearchInputEvent.Action.OnQueryChange(it)) },
         shape = CircleShape,
@@ -181,23 +213,7 @@ private fun SearchInputBar(
             disabledIndicatorColor = Color.Transparent,
             errorIndicatorColor = Color.Transparent
         ),
-        leadingIcon = {
-            IconButton(onClick = { onUiEvent(SearchInputEvent.UI.OnNavUp) }) {
-                Icon(
-                    imageVector = BgmIconsMirrored.ArrowBack,
-                    contentDescription = stringResource(Res.string.global_back)
-                )
-            }
-        },
         textStyle = MaterialTheme.typography.bodyLarge,
-        trailingIcon = {
-            IconButton(onClick = { onActionEvent(SearchInputEvent.Action.OnSearch) }) {
-                Icon(
-                    imageVector = BgmIcons.Search,
-                    contentDescription = stringResource(Res.string.global_search)
-                )
-            }
-        }
     )
 }
 

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputScreen.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
@@ -33,7 +34,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -95,12 +95,8 @@ private fun SearchInputScreen(
     onUiEvent: (SearchInputEvent.UI) -> Unit,
     onActionEvent: (SearchInputEvent.Action) -> Unit,
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-
     Scaffold(
-        modifier = Modifier
-            .fillMaxSize()
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.fillMaxSize(),
         topBar = {
             Box(
                 modifier = Modifier
@@ -151,7 +147,7 @@ private fun SearchInputScreen(
             onRefresh = { onActionEvent(SearchInputEvent.Action.OnRefresh(it)) },
             baseState = baseState,
         ) { state ->
-            SearchInputScreenContent(state, onUiEvent, onActionEvent)
+            SearchInputScreenContent(state, onActionEvent)
         }
     }
 }
@@ -160,11 +156,10 @@ private fun SearchInputScreen(
 @Composable
 private fun SearchInputScreenContent(
     state: SearchInputState,
-    onUiEvent: (SearchInputEvent.UI) -> Unit,
     onActionEvent: (SearchInputEvent.Action) -> Unit,
 ) {
     when {
-        state.suggestions.isNotEmpty() -> LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        state.suggestions.isNotEmpty() -> LazyColumn(modifier = Modifier.fillMaxSize()) {
             items(state.suggestions) {
                 Text(
                     modifier = Modifier
@@ -184,7 +179,6 @@ private fun SearchInputScreenContent(
 
         state.histories.isNotEmpty() && state.query.text.isBlank() -> SearchInputHistory(
             state = state,
-            onUiEvent = onUiEvent,
             onActionEvent = onActionEvent
         )
     }
@@ -221,10 +215,9 @@ private fun SearchInputBar(
 @Composable
 private fun SearchInputHistory(
     state: SearchInputState,
-    onUiEvent: (SearchInputEvent.UI) -> Unit,
     onActionEvent: (SearchInputEvent.Action) -> Unit,
 ) {
-    Column {
+    Column(modifier = Modifier.fillMaxSize()) {
         Spacer(modifier = Modifier.height(24.dp))
 
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -249,21 +242,39 @@ private fun SearchInputHistory(
                 .fillMaxWidth()
                 .weight(1f)
         ) {
-            items(state.histories) {
-                Text(
-                    modifier = Modifier
-                        .clickable {
-                            onActionEvent(SearchInputEvent.Action.OnQueryChange(it.asTextFieldValue()))
-                            onActionEvent(SearchInputEvent.Action.OnSearch)
-                        }
-                        .fillMaxWidth()
-                        .padding(horizontal = contentMargin, vertical = 12.dp),
-                    text = it,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontWeight = FontWeight.Normal
-                )
+            items(state.histories, key = { it }) { keyword ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable {
+                                onActionEvent(SearchInputEvent.Action.OnQueryChange(keyword.asTextFieldValue()))
+                                onActionEvent(SearchInputEvent.Action.OnSearch)
+                            }
+                            .padding(start = contentMargin, top = 12.dp, bottom = 12.dp),
+                        text = keyword,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Normal,
+                    )
+                    IconButton(
+                        onClick = {
+                            onActionEvent(SearchInputEvent.Action.OnDeleteHistory(keyword))
+                        },
+                    ) {
+                        Icon(
+                            imageVector = BgmIcons.Close,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            contentDescription = stringResource(Res.string.global_clear),
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(contentMargin - 12.dp))
+                }
             }
         }
     }
 }
+

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputScreen.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/SearchInputScreen.kt
@@ -42,6 +42,7 @@ import com.xiaoyv.bangumi.core_resource.resources.Res
 import com.xiaoyv.bangumi.core_resource.resources.global_back
 import com.xiaoyv.bangumi.core_resource.resources.global_clear
 import com.xiaoyv.bangumi.core_resource.resources.global_search
+import com.xiaoyv.bangumi.core_resource.resources.search_clear_history_confirm
 import com.xiaoyv.bangumi.core_resource.resources.search_history
 import com.xiaoyv.bangumi.features.search.input.business.SearchInputEvent
 import com.xiaoyv.bangumi.features.search.input.business.SearchInputSideEffect
@@ -49,6 +50,8 @@ import com.xiaoyv.bangumi.features.search.input.business.SearchInputState
 import com.xiaoyv.bangumi.features.search.input.business.SearchInputViewModel
 import com.xiaoyv.bangumi.shared.core.mvi.BaseState
 import com.xiaoyv.bangumi.shared.core.utils.asTextFieldValue
+import com.xiaoyv.bangumi.shared.ui.component.dialog.alert.BgmAlertDialog
+import com.xiaoyv.bangumi.shared.ui.component.dialog.alert.rememberAlertDialogState
 import com.xiaoyv.bangumi.shared.ui.component.layout.state.StateLayout
 import com.xiaoyv.bangumi.shared.ui.component.navigation.Screen
 import com.xiaoyv.bangumi.shared.ui.component.text.BmgTextField
@@ -217,17 +220,24 @@ private fun SearchInputHistory(
     state: SearchInputState,
     onActionEvent: (SearchInputEvent.Action) -> Unit,
 ) {
+    val clearHistoryDialogState = rememberAlertDialogState()
+
+    BgmAlertDialog(
+        state = clearHistoryDialogState,
+        text = stringResource(Res.string.search_clear_history_confirm),
+        onConfirm = { onActionEvent(SearchInputEvent.Action.OnClearHistory) },
+    )
+
     Column(modifier = Modifier.fillMaxSize()) {
-        Spacer(modifier = Modifier.height(24.dp))
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
-                modifier = Modifier.padding(vertical = 16.dp, horizontal = contentMargin),
+                modifier = Modifier.padding(vertical = 12.dp, horizontal = contentMargin),
                 text = stringResource(Res.string.search_history),
                 style = MaterialTheme.typography.titleLarge
             )
             Spacer(modifier = Modifier.weight(1f))
-            IconButton(onClick = { onActionEvent(SearchInputEvent.Action.OnClearHistory) }) {
+            IconButton(onClick = { clearHistoryDialogState.show() }) {
                 Icon(
                     imageVector = BgmIcons.Delete,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/business/SearchInputEvent.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/business/SearchInputEvent.kt
@@ -19,6 +19,7 @@ sealed class SearchInputEvent {
         data object OnSearch : Action()
         data class OnRefresh(val loading: Boolean) : Action()
         data object OnClearHistory : Action()
+        data class OnDeleteHistory(val keyword: String) : Action()
         data class OnQueryChange(val query: TextFieldValue) : Action()
     }
 }

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/business/SearchInputViewModel.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/business/SearchInputViewModel.kt
@@ -55,7 +55,7 @@ class SearchInputViewModel(
     }
 
     private fun refreshHistory() = action {
-        val histories = searchHistory.queryAllHistory(limit = 10).executeAsList()
+        val histories = searchHistory.queryAllHistory().executeAsList()
             .map { it.keyword }
             .filter { it.isNotBlank() }
 
@@ -68,11 +68,17 @@ class SearchInputViewModel(
             is SearchInputEvent.Action.OnQueryChange -> onQueryChange(event.query)
             is SearchInputEvent.Action.OnSearch -> onSearch()
             is SearchInputEvent.Action.OnClearHistory -> onClearHistory()
+            is SearchInputEvent.Action.OnDeleteHistory -> onDeleteHistory(event.keyword)
         }
     }
 
     private fun onClearHistory() = action {
         searchHistory.clearHistory()
+        refreshHistory()
+    }
+
+    private fun onDeleteHistory(keyword: String) = action {
+        searchHistory.deleteHistory(keyword)
         refreshHistory()
     }
 

--- a/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/business/SearchInputViewModel.kt
+++ b/features/search/input/src/commonMain/kotlin/com/xiaoyv/bangumi/features/search/input/business/SearchInputViewModel.kt
@@ -31,6 +31,7 @@ class SearchInputViewModel(
 ) : BaseViewModel<SearchInputState, SearchInputSideEffect, SearchInputEvent.Action>(savedStateHandle) {
     private val search = mutableStateFlowOf(args.query)
     private val searchHistory = System.database.appSearchHistoryQueries
+    private var searchSubmitted = false
 
     init {
         search
@@ -88,8 +89,11 @@ class SearchInputViewModel(
     }
 
     private fun onSearch() = action {
+        if (searchSubmitted) return@action
+
         val text = state.content.query.text.trim()
         if (text.isNotBlank()) {
+            searchSubmitted = true
             searchHistory.deleteHistory(text)
             searchHistory.saveHistory(
                 keyword = text,

--- a/features/settings/main/src/commonMain/kotlin/com/xiaoyv/bangumi/features/settings/main/business/SettingsMainViewModel.kt
+++ b/features/settings/main/src/commonMain/kotlin/com/xiaoyv/bangumi/features/settings/main/business/SettingsMainViewModel.kt
@@ -6,7 +6,9 @@ import com.xiaoyv.bangumi.core_resource.resources.settings_clean_cache_success
 import com.xiaoyv.bangumi.shared.System
 import com.xiaoyv.bangumi.shared.core.mvi.BaseSyntax
 import com.xiaoyv.bangumi.shared.core.mvi.BaseViewModel
+import com.xiaoyv.bangumi.shared.core.utils.runResult
 import com.xiaoyv.bangumi.shared.data.manager.app.UserManager
+import com.xiaoyv.bangumi.shared.data.repository.DatabaseRepository
 import org.jetbrains.compose.resources.getString
 
 /**
@@ -18,6 +20,7 @@ import org.jetbrains.compose.resources.getString
 class SettingsMainViewModel(
     savedStateHandle: SavedStateHandle,
     private val userManager: UserManager,
+    private val databaseRepository: DatabaseRepository,
 ) : BaseViewModel<SettingsMainState, SettingsMainSideEffect, SettingsMainEvent.Action>(savedStateHandle) {
 
     override fun initSate(onCreate: Boolean) = SettingsMainState()
@@ -39,9 +42,13 @@ class SettingsMainViewModel(
     }
 
     private fun onCleanCache() = action {
-        withActionLoading { System.cleanCache() }
-            .onSuccess {
-                postToast { getString(Res.string.settings_clean_cache_success) }
+        withActionLoading {
+            runResult {
+                System.cleanCache().getOrThrow()
+                databaseRepository.clearSubjectPreviewMappings()
             }
+        }.onSuccess {
+            postToast { getString(Res.string.settings_clean_cache_success) }
+        }
     }
 }

--- a/features/subject/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/subject/detail/business/SubjectDetailState.kt
+++ b/features/subject/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/subject/detail/business/SubjectDetailState.kt
@@ -56,6 +56,8 @@ data class SubjectDetailState(
 
     @Transient
     val loading: LoadingState = LoadingState.NotLoading,
+    @Transient
+    val previewLoading: LoadingState = LoadingState.Loading,
 ) {
 
     fun magnetQuery(episode: ComposeEpisode = ComposeEpisode.Empty): String {
@@ -91,7 +93,7 @@ data class SubjectDetailState(
             )
         }
         // 动画和三次元 才显示预览 TAB
-        if (photo.doubanMediaId.isNotBlank() && (subject.type == SubjectType.REAL || subject.type == SubjectType.ANIME)) {
+        if (subject.type == SubjectType.REAL || subject.type == SubjectType.ANIME) {
             items.add(ComposeTextTab(SubjectDetailTab.PREVIEW, Res.string.subject_tab_preview))
         }
         items.add(ComposeTextTab(SubjectDetailTab.CHARACTER, Res.string.subject_tab_character))

--- a/features/subject/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/subject/detail/business/SubjectDetailViewModel.kt
+++ b/features/subject/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/subject/detail/business/SubjectDetailViewModel.kt
@@ -28,6 +28,8 @@ import com.xiaoyv.bangumi.shared.data.repository.readViewModelCache
 import com.xiaoyv.bangumi.shared.data.repository.writeViewModelCache
 import com.xiaoyv.bangumi.shared.ui.component.navigation.Screen
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -129,21 +131,33 @@ class SubjectDetailViewModel(
      * 刷新豆瓣预览和巡礼图片
      */
     private suspend fun onRefreshParadeAndPhoto() = subAction {
-        awaitAll(
-            block1 = { subjectRepository.fetchSubjectParade(args.subjectId).recover { ComposeParade.Empty } },
-            block2 = { subjectRepository.fetchSubjectPreview(stateRaw.subject).recover { ComposeDoubanPhoto.Empty } },
-            block3 = { subjectRepository.fetchMySubjectTags(args.subjectId).recover { emptyList() } },
-        ).onSuccess {
+        val subject = stateRaw.subject
+        reduceContent { state.copy(previewLoading = LoadingState.Loading) }
+
+        coroutineScope {
+            val parade = async { subjectRepository.fetchSubjectParade(args.subjectId).recover { ComposeParade.Empty } }
+            val photo = async { subjectRepository.fetchSubjectPreview(subject).recover { ComposeDoubanPhoto.Empty } }
+            val myTags = async { subjectRepository.fetchMySubjectTags(args.subjectId).recover { emptyList() } }
+
+            val preview = photo.await().getOrThrow()
             reduceContent {
                 state.copy(
-                    parade = it.data1,
-                    photo = it.data2,
-                    myTags = it.data3.toPersistentList(),
+                    photo = preview,
+                    previewLoading = LoadingState.NotLoading,
                 )
             }
 
-            personalStateStore.updateSubject(args.subjectId, stateRaw.subject)
+            val refreshedParade = parade.await().getOrThrow()
+            val refreshedTags = myTags.await().getOrThrow()
+            reduceContent {
+                state.copy(
+                    parade = refreshedParade,
+                    myTags = refreshedTags.toPersistentList(),
+                )
+            }
         }
+
+        personalStateStore.updateSubject(args.subjectId, subject)
     }
 
     private fun onUpdateEpisodeCollection(episodes: List<ComposeEpisode>, type: Int) = action {

--- a/features/subject/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/subject/detail/page/SubjectDetailPreviewScreen.kt
+++ b/features/subject/detail/src/commonMain/kotlin/com/xiaoyv/bangumi/features/subject/detail/page/SubjectDetailPreviewScreen.kt
@@ -5,8 +5,10 @@ import androidx.compose.runtime.remember
 import com.xiaoyv.bangumi.features.preivew.album.PreviewAlbumRoute
 import com.xiaoyv.bangumi.features.subject.detail.business.SubjectDetailEvent
 import com.xiaoyv.bangumi.features.subject.detail.business.SubjectDetailState
+import com.xiaoyv.bangumi.shared.core.types.LoadingState
 import com.xiaoyv.bangumi.shared.core.types.list.ListAlbumType
 import com.xiaoyv.bangumi.shared.data.model.request.list.album.ListAlbumParam
+import com.xiaoyv.bangumi.shared.ui.component.layout.state.StateLoadingLayout
 
 /**
  * [SubjectDetailTopicScreen]
@@ -19,16 +21,20 @@ fun SubjectDetailPreviewScreen(
     onUiEvent: (SubjectDetailEvent.UI) -> Unit,
     onActionEvent: (SubjectDetailEvent.Action) -> Unit,
 ) {
-    PreviewAlbumRoute(
-        param = remember(state.photo.doubanMediaId, state.photo.doubanMediaType) {
-            ListAlbumParam(
-                type = ListAlbumType.SUBJECT_PREVIEW,
-                doubanId = state.photo.doubanMediaId,
-                doubanType = state.photo.doubanMediaType
-            )
-        },
-        onNavScreen = {
-            onUiEvent(SubjectDetailEvent.UI.OnNavScreen(it))
-        }
-    )
+    if (state.previewLoading == LoadingState.Loading) {
+        StateLoadingLayout()
+    } else {
+        PreviewAlbumRoute(
+            param = remember(state.photo.doubanMediaId, state.photo.doubanMediaType) {
+                ListAlbumParam(
+                    type = ListAlbumType.SUBJECT_PREVIEW,
+                    doubanId = state.photo.doubanMediaId,
+                    doubanType = state.photo.doubanMediaType
+                )
+            },
+            onNavScreen = {
+                onUiEvent(SubjectDetailEvent.UI.OnNavScreen(it))
+            }
+        )
+    }
 }

--- a/shared/core-native/src/commonMain/sqldelight/com/xiaoyv/bangumi/shared/native/AppSearchHistory.sq
+++ b/shared/core-native/src/commonMain/sqldelight/com/xiaoyv/bangumi/shared/native/AppSearchHistory.sq
@@ -12,8 +12,7 @@ VALUES (:keyword, :timestamp);
 -- 查询所有搜索历史，按时间倒序
 queryAllHistory:
 SELECT * FROM SqlHistory
-ORDER BY timestamp DESC
-LIMIT :limit;
+ORDER BY timestamp DESC;
 
 -- 查询某个关键词是否存在
 queryHistory:

--- a/shared/core-native/src/commonMain/sqldelight/com/xiaoyv/bangumi/shared/native/AppSerializable.sq
+++ b/shared/core-native/src/commonMain/sqldelight/com/xiaoyv/bangumi/shared/native/AppSerializable.sq
@@ -19,5 +19,8 @@ DELETE FROM SqlSerializable WHERE key = ?;
 deleteAll:
 DELETE FROM SqlSerializable;
 
+deleteSubjectPreviewMappings:
+DELETE FROM SqlSerializable WHERE key LIKE 'DB6-%';
+
 deleteExpired:
 DELETE FROM SqlSerializable WHERE createdAt < ?;

--- a/shared/core-resource/src/androidMain/res/values/strings.xml
+++ b/shared/core-resource/src/androidMain/res/values/strings.xml
@@ -279,6 +279,7 @@
     <string name="settings_live2d_voice">触摸语音</string>
 
     <string name="search_history">搜索历史</string>
+    <string name="search_clear_history_confirm">确定删除所有历史记录吗？</string>
 
     <string name="subject_rate_count">（%1$d人评分）</string>
     <string name="subject_locked">条目已锁定</string>

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/api/DouBanApi.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/api/DouBanApi.kt
@@ -2,6 +2,7 @@ package com.xiaoyv.bangumi.shared.data.api
 
 import com.xiaoyv.bangumi.shared.core.types.AppDsl
 import com.xiaoyv.bangumi.shared.data.model.response.db.ComposeDoubanPhoto
+import com.xiaoyv.bangumi.shared.data.model.response.db.ComposeDoubanSearch
 import com.xiaoyv.bangumi.shared.data.model.response.db.ComposeDoubanSuggest
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Path
@@ -22,6 +23,14 @@ interface DouBanApi {
         @Query("apikey") apikey: String = "0dad551ec0f84ed02907ff5c42e8ec70",
     ): ComposeDoubanSuggest
 
+    @GET("https://frodo.douban.com/api/v2/search/subjects")
+    suspend fun queryDouBanSubjects(
+        @Query("q") q: String,
+        @Query("sort") sort: String = "relevance",
+        @Query("need_types") needTypes: Int = 0,
+        @Query("count") count: Int = 20,
+        @Query("apikey") apikey: String = "0dad551ec0f84ed02907ff5c42e8ec70",
+    ): ComposeDoubanSearch
 
     @GET("https://frodo.douban.com/api/v2/{type}/{mediaId}/photos")
     suspend fun queryDouBanPhotoList(

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/db/ComposeDoubanSearch.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/model/response/db/ComposeDoubanSearch.kt
@@ -1,0 +1,43 @@
+package com.xiaoyv.bangumi.shared.data.model.response.db
+
+import androidx.compose.runtime.Immutable
+import com.xiaoyv.bangumi.shared.core.utils.serialization.SerializeList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Immutable
+@Serializable
+data class ComposeDoubanSearch(
+    @SerialName("banned") val banned: String = "",
+    @SerialName("types") val types: SerializeList<Type> = persistentListOf(),
+    /** 当前 /search/subjects 响应的候选列表位于根节点。 */
+    @SerialName("items") val items: SerializeList<ComposeDoubanSuggestCard> = persistentListOf(),
+    @SerialName("show_more_subjects") val showMoreSubjects: Boolean = false,
+    @SerialName("target_name") val targetName: String = "",
+    @SerialName("total") val total: Int = 0,
+    @SerialName("start") val start: Int = 0,
+    @SerialName("count") val count: Int = 0,
+    /** 兼容此前返回的 subjects.items 嵌套格式。 */
+    @SerialName("subjects") val subjects: Subjects = Subjects(),
+) {
+    @Immutable
+    @Serializable
+    data class Type(
+        @SerialName("type") val type: String = "",
+        @SerialName("type_name") val typeName: String = "",
+        @SerialName("total") val total: String = "",
+        @SerialName("uuids") val uuids: SerializeList<String> = persistentListOf(),
+    )
+
+    @Immutable
+    @Serializable
+    data class Subjects(
+        @SerialName("items") val items: SerializeList<ComposeDoubanSuggestCard> = persistentListOf(),
+        @SerialName("show_more_subjects") val showMoreSubjects: Boolean = false,
+        @SerialName("target_name") val targetName: String = "",
+        @SerialName("total") val total: Int = 0,
+        @SerialName("start") val start: Int = 0,
+        @SerialName("count") val count: Int = 0,
+    )
+}

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/DatabaseRepository.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/DatabaseRepository.kt
@@ -34,4 +34,7 @@ interface DatabaseRepository {
     fun put(key: String, value: Int)
     fun put(key: String, value: Float)
     fun <T> put(key: String, data: T, serializable: KSerializer<T>)
+
+    /** 清理 BGM 条目与豆瓣条目的预览关联缓存。 */
+    fun clearSubjectPreviewMappings()
 }

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/impl/DatabaseRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/impl/DatabaseRepositoryImpl.kt
@@ -92,6 +92,10 @@ class DatabaseRepositoryImpl(val json: Json) : DatabaseRepository {
         put(key, json.encodeToString(serializable, data))
     }
 
+    override fun clearSubjectPreviewMappings() {
+        database.appSerializableQueries.deleteSubjectPreviewMappings()
+    }
+
     override fun put(key: String, value: String) {
         database.appSerializableQueries.insertOrReplace(
             key = key,

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/impl/ImageRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/impl/ImageRepositoryImpl.kt
@@ -117,28 +117,32 @@ class ImageRepositoryImpl(
                 }
             }
 
-            ListAlbumType.SUBJECT_PREVIEW -> client.requestDouBanApi {
-                client.dbApi
-                    .queryDouBanPhotoList(param.doubanId, param.doubanType, page.toApiOffset(size), size)
-                    .copy(doubanMediaId = param.doubanId)
-                    .photos.map {
-                        val hexColor = parseHtmlHexColor(it.image.primaryColor.orEmpty()) ?: Color.LightGray
-                        val largeImage = it.displayLargeImage
+            ListAlbumType.SUBJECT_PREVIEW -> {
+                if (param.doubanId.isBlank() || param.doubanType.isBlank()) {
+                    Result.success(emptyList())
+                } else client.requestDouBanApi {
+                    client.dbApi
+                        .queryDouBanPhotoList(param.doubanId, param.doubanType, page.toApiOffset(size), size)
+                        .copy(doubanMediaId = param.doubanId)
+                        .photos.map {
+                            val hexColor = parseHtmlHexColor(it.image.primaryColor.orEmpty()) ?: Color.LightGray
+                            val largeImage = it.displayLargeImage
 
-                        ComposeGallery(
-                            id = largeImage.url.orEmpty(),
-                            type = param.type,
-                            width = largeImage.width,
-                            height = largeImage.height,
-                            image = largeImage.url.orEmpty(),
-                            original = largeImage.url.orEmpty(),
-                            color = listOf(
-                                (hexColor.red * 255).roundToInt().coerceIn(0, 255),
-                                (hexColor.green * 255).roundToInt().coerceIn(0, 255),
-                                (hexColor.blue * 255).roundToInt().coerceIn(0, 255),
+                            ComposeGallery(
+                                id = largeImage.url.orEmpty(),
+                                type = param.type,
+                                width = largeImage.width,
+                                height = largeImage.height,
+                                image = largeImage.url.orEmpty(),
+                                original = largeImage.url.orEmpty(),
+                                color = listOf(
+                                    (hexColor.red * 255).roundToInt().coerceIn(0, 255),
+                                    (hexColor.green * 255).roundToInt().coerceIn(0, 255),
+                                    (hexColor.blue * 255).roundToInt().coerceIn(0, 255),
+                                )
                             )
-                        )
-                    }
+                        }
+                }
             }
 
             else -> error("not support")

--- a/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/impl/SubjectRepositoryImpl.kt
+++ b/shared/data/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/data/repository/impl/SubjectRepositoryImpl.kt
@@ -14,7 +14,6 @@ import com.xiaoyv.bangumi.shared.core.types.list.ListTagType
 import com.xiaoyv.bangumi.shared.core.utils.debugLog
 import com.xiaoyv.bangumi.shared.core.utils.fetchAllPages
 import com.xiaoyv.bangumi.shared.core.utils.runResult
-import com.xiaoyv.bangumi.shared.core.utils.substringBeforeSymbol
 import com.xiaoyv.bangumi.shared.core.utils.toApiPage
 import com.xiaoyv.bangumi.shared.data.api.client.BgmApiClient
 import com.xiaoyv.bangumi.shared.data.model.request.list.subject.ListSubjectParam
@@ -32,7 +31,6 @@ import com.xiaoyv.bangumi.shared.data.model.response.bgm.subject.ComposeSubjectS
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.subject.ComposeSubjectWebInfo
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.ComposeTag
 import com.xiaoyv.bangumi.shared.data.model.response.bgm.topic.ComposeTopic
-import com.xiaoyv.bangumi.shared.data.model.response.bgm.chineseNames
 import com.xiaoyv.bangumi.shared.data.model.response.db.ComposeDoubanPhoto
 import com.xiaoyv.bangumi.shared.data.model.response.db.ComposeDoubanSuggest
 import com.xiaoyv.bangumi.shared.data.model.response.db.ComposeDoubanSuggestCard
@@ -48,6 +46,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlin.math.abs
 
 /**
  * [SubjectRepositoryImpl]
@@ -133,42 +132,29 @@ class SubjectRepositoryImpl(
 
     override suspend fun fetchSubjectPreview(subject: ComposeSubject): Result<ComposeDoubanPhoto> = runResult {
         val key = "DB6-${subject.id}"
-        val chineseNames = subject.infobox.chineseNames(subject.nameCn)
-
         var suggestCard = databaseRepository.get(key, ComposeDoubanSuggestCard.Empty, ComposeDoubanSuggestCard.serializer())
-        if (suggestCard == ComposeDoubanSuggestCard.Empty) {
-            val cards = coroutineScope {
-                awaitAll(
-                    *chineseNames
-                        .flatMap {
-                            if (it.length > 10) listOf(it, it.substringBeforeSymbol(), it.dropLast(2))
-                            else listOf(it, it.substringBeforeSymbol())
-                        }
-                        .map {
-                            async {
-                                runCatching { client.dbApi.queryDouBanSuggestion(q = it).cards }.getOrNull().orEmpty()
-                            }
-                        }
-                        .toTypedArray()
-                ).flatMap { it }
-            }
 
-            val mediaCards = cards
-                .filter { it.targetType == "tv" || it.targetType == "movie" }
-                .sortedBy {
-                    if (subject.type == SubjectType.REAL) {
-                        if (it.target.hasLinewatch) 0 else 1
-                    } else {
-                        if (it.target.hasLinewatch) 1 else 0
-                    }
-                }
-            val card = mediaCards.find { chineseNames.contains(it.target.title) }
-                ?: mediaCards.firstOrNull()
+        if (suggestCard == ComposeDoubanSuggestCard.Empty) {
+            val subjectYear = subject.airtime.year
+            val searchItems = coroutineScope {
+                awaitAll(
+                    async { client.dbApi.queryDouBanSubjects(q = subject.nameCn) },
+                    async { client.dbApi.queryDouBanSubjects(q = subject.name) },
+                ).flatMap { searchResponse ->
+                    searchResponse.items.ifEmpty { searchResponse.subjects.items }
+                }.distinctBy { it.targetType to it.targetId }
+            }
+            val mediaCards = searchItems.filter { it.targetType == "tv" || it.targetType == "movie" }
+            val card = mediaCards.firstOrNull { it.target.year.toIntOrNull() == subjectYear }
+                ?: mediaCards.minByOrNull { abs((it.target.year.toIntOrNull() ?: Int.MAX_VALUE) - subjectYear) }
 
             if (card != null) databaseRepository.put(key, card, ComposeDoubanSuggestCard.serializer())
             suggestCard = card ?: ComposeDoubanSuggestCard.Empty
         }
-        if (suggestCard == ComposeDoubanSuggestCard.Empty) ComposeDoubanPhoto.Empty else {
+
+        if (suggestCard == ComposeDoubanSuggestCard.Empty) {
+            ComposeDoubanPhoto.Empty
+        } else {
             client.dbApi
                 .queryDouBanPhotoList(suggestCard.targetId, suggestCard.targetType)
                 .copy(doubanMediaId = suggestCard.targetId, doubanMediaType = suggestCard.targetType)

--- a/shared/ui-liquid/src/skikoMain/kotlin/com/kyant/backdrop/catalog/utils/InteractiveHighlight.skiko.kt
+++ b/shared/ui-liquid/src/skikoMain/kotlin/com/kyant/backdrop/catalog/utils/InteractiveHighlight.skiko.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.asComposeShader
 import androidx.compose.ui.util.fastCoerceIn
 import com.kyant.backdrop.getRuntimeShaderCache
 import org.jetbrains.skia.RuntimeShaderBuilder
@@ -23,7 +24,7 @@ internal actual fun createInteractiveHighlightShader(
         uniform("radius", radius)
         uniform("position", position.x.fastCoerceIn(0f, size.width), position.y.fastCoerceIn(0f, size.height))
     }
-    return shaderBuilder.makeShader()
+    return shaderBuilder.makeShader().asComposeShader()
 }
 
 internal const val InteractiveHighlightShaderString = """

--- a/shared/ui-liquid/src/skikoMain/kotlin/com/kyant/backdrop/highlight/HighlightStyle.skiko.kt
+++ b/shared/ui-liquid/src/skikoMain/kotlin/com/kyant/backdrop/highlight/HighlightStyle.skiko.kt
@@ -1,11 +1,12 @@
 package com.kyant.backdrop.highlight
 
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.asComposeShader
 import com.kyant.backdrop.AmbientHighlightShaderString
 import com.kyant.backdrop.DefaultHighlightShaderString
 import com.kyant.backdrop.getRuntimeShaderCache
 import org.jetbrains.skia.RuntimeShaderBuilder
-import org.jetbrains.skia.Shader
 
 internal actual fun createDefaultAmbientShader(
     size: Size,
@@ -24,7 +25,7 @@ internal actual fun createDefaultAmbientShader(
         uniform("angle", angle)
         uniform("falloff", falloff)
     }
-    return shaderBuilder.makeShader()
+    return shaderBuilder.makeShader().asComposeShader()
 }
 
 internal actual fun createHighlightAmbientShader(
@@ -44,5 +45,5 @@ internal actual fun createHighlightAmbientShader(
         uniform("angle", angle)
         uniform("falloff", falloff)
     }
-    return shaderBuilder.makeShader()
+    return shaderBuilder.makeShader().asComposeShader()
 }

--- a/shared/ui/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/ui/component/navigation/Screen.kt
+++ b/shared/ui/src/commonMain/kotlin/com/xiaoyv/bangumi/shared/ui/component/navigation/Screen.kt
@@ -198,7 +198,7 @@ sealed class Screen(
     data class SearchInput(val query: String = "") : Screen(SCREEN_ROUTE_SEARCH_INPUT)
 
     @Serializable
-    data class SearchResult(val query: String) : Screen(SCREEN_ROUTE_SEARCH_RESULT)
+    data class SearchResult(val query: String) : Screen(SCREEN_ROUTE_SEARCH_RESULT, LaunchMode.SINGLE_TOP)
 
     @Serializable
     data class MikanResources(val mikanId: String, val groupId: String, val groupName: String) :


### PR DESCRIPTION
搜索优化
* 美化搜索框
* 显示不限量的历史记录
* 在每个历史记录旁边加上了删除按钮
* 在点击清空历史记录时加入了弹窗提醒

预览优化
* 原始代码采用 `https://frodo.douban.com/api/v2/search/suggestion` 来关联bgm和豆瓣词条。但是这个是专门用来做搜索补全的，专门的搜索API是 `https://frodo.douban.com/api/v2/search/subjects?q=X`，并且不会以年份这个强属性来筛选，这导致大量的误匹配。
* 目前发现的误匹配包括但不限于：
    - 新世纪福音战士 剧场版 Air/真心为你
    - 命运石之门 负荷领域的既视感
    - 剧场版魔法少女小圆 新篇 叛逆的物语
    - 命运之夜 无限剑制 第二季
    - 辉夜大小姐系列 （包括第一季、初吻不会结束）
    - 我们仍未知道那天所看见花的名字（包括TV、剧场版）
* 本次PR重写了匹配算法，不再拆分标题，不再区分hasLinewatch。而是将**中文和日文标题**全部放入 `/search/subjects` API中搜索。将候选集中年份完全匹配的直接返回，否则按照年份的接近顺序排列，取年份最接近的返回。
* 实测目前的算法下，bgm的条目均可以正常关联豆瓣词条，除了禁播动画：进击的巨人系列、寄生兽：生命的准则、东京食尸鬼系列、死亡笔记 这几部无法关联。因为豆瓣在匿名请求下无法搜索这些动画。
* 在动画和三次元条目下始终显示预览，如果没有图片就显示「暂无内容」